### PR TITLE
g3: Use interruptible waits to fix high load average

### DIFF
--- a/arch/arm/mach-msm/mpm-of.c
+++ b/arch/arm/mach-msm/mpm-of.c
@@ -615,7 +615,11 @@ static void msm_mpm_work_fn(struct work_struct *work)
 	unsigned long flags;
 	while (1) {
 		bool allow;
-		wait_for_completion(&wake_wq);
+
+		if (wait_for_completion_interruptible(
+			&wake_wq) != 0)
+			continue;
+
 		spin_lock_irqsave(&msm_mpm_lock, flags);
 		allow = msm_mpm_irqs_detectable(true) &&
 				msm_mpm_gpio_irqs_detectable(true);

--- a/arch/arm/mach-msm/rpm-smd.c
+++ b/arch/arm/mach-msm/rpm-smd.c
@@ -850,7 +850,9 @@ static void msm_rpm_smd_work(struct work_struct *work)
 	char buf[MAX_ERR_BUFFER_SIZE] = {0};
 
 	while (1) {
-		wait_for_completion(&data_ready);
+		if (wait_for_completion_interruptible(
+			&data_ready) != 0)
+			continue;
 
 		spin_lock(&msm_rpm_data.smd_lock_read);
 		while (smd_is_pkt_avail(msm_rpm_data.ch_info)) {

--- a/drivers/cpufreq/cpufreq_ondemand.c
+++ b/drivers/cpufreq/cpufreq_ondemand.c
@@ -1243,9 +1243,10 @@ static int dbs_sync_thread(void *data)
 	this_dbs_info = &per_cpu(od_cpu_dbs_info, cpu);
 
 	while (1) {
-		wait_event(this_dbs_info->sync_wq,
+		if (wait_event_interruptible(this_dbs_info->sync_wq,
 			   sync_pending(this_dbs_info) ||
-			   kthread_should_stop());
+			   kthread_should_stop()) != 0)
+			continue;
 
 		if (kthread_should_stop())
 			break;

--- a/drivers/power/bq24296_charger.c
+++ b/drivers/power/bq24296_charger.c
@@ -1321,7 +1321,9 @@ static __ref int do_phihong_checker(void *data)
 	static int count = 0;
 	static int usb_present;
 	while (!kthread_should_stop()) {
-		wait_for_completion(&chip->phihong_complete);
+		while (wait_for_completion_interruptible(
+			&chip->phihong_complete) != 0)
+			;
 		INIT_COMPLETION(chip->phihong_complete);
 		usb_present = bq24296_is_charger_present(chip);
 		switch(chip->phihong) {

--- a/drivers/slimbus/slim-msm-ngd.c
+++ b/drivers/slimbus/slim-msm-ngd.c
@@ -1010,7 +1010,9 @@ static int ngd_slim_rx_msgq_thread(void *data)
 
 	while (!kthread_should_stop()) {
 		set_current_state(TASK_INTERRUPTIBLE);
-		wait_for_completion(notify);
+		while (wait_for_completion_interruptible(
+			notify) != 0)
+			;
 		/* 1 irq notification per message */
 		if (dev->use_rx_msgqs != MSM_MSGQ_ENABLED) {
 			msm_slim_rx_dequeue(dev, (u8 *)buffer);
@@ -1048,7 +1050,9 @@ static int ngd_notify_slaves(void *data)
 	int ret, i = 0;
 	while (!kthread_should_stop()) {
 		set_current_state(TASK_INTERRUPTIBLE);
-		wait_for_completion(&dev->qmi.slave_notify);
+		while (wait_for_completion_interruptible(
+			&dev->qmi.slave_notify) != 0)
+			;
 		/* Probe devices for first notification */
 		if (!i) {
 			dev->err = 0;

--- a/drivers/thermal/msm_thermal.c
+++ b/drivers/thermal/msm_thermal.c
@@ -904,7 +904,9 @@ static __ref int do_hotplug(void *data)
 		return -EINVAL;
 
 	while (!kthread_should_stop()) {
-		wait_for_completion(&hotplug_notify_complete);
+		while (wait_for_completion_interruptible(
+			&hotplug_notify_complete) != 0)
+			;
 		INIT_COMPLETION(hotplug_notify_complete);
 		mask = 0;
 
@@ -1346,7 +1348,9 @@ static __ref int do_freq_mitigation(void *data)
 	uint32_t cpu = 0, max_freq_req = 0, min_freq_req = 0;
 
 	while (!kthread_should_stop()) {
-		wait_for_completion(&freq_mitigation_complete);
+		while (wait_for_completion_interruptible(
+			&freq_mitigation_complete) != 0)
+			;
 		INIT_COMPLETION(freq_mitigation_complete);
 
 		get_online_cpus();

--- a/drivers/video/msm/mdss/mdss_dsi_host.c
+++ b/drivers/video/msm/mdss/mdss_dsi_host.c
@@ -1334,7 +1334,10 @@ static int dsi_event_thread(void *data)
 	spin_lock_init(&ev->event_lock);
 
 	while (1) {
-		wait_event(ev->event_q, (ev->event_pndx != ev->event_gndx));
+		if (wait_event_interruptible(ev->event_q,
+			(ev->event_pndx != ev->event_gndx)) != 0)
+			continue;
+
 		spin_lock_irqsave(&ev->event_lock, flag);
 		evq = &ev->todo_list[ev->event_gndx++];
 		todo = evq->todo;

--- a/drivers/video/msm/mdss/mdss_edp.c
+++ b/drivers/video/msm/mdss/mdss_edp.c
@@ -837,7 +837,10 @@ static int edp_event_thread(void *data)
 	ep = (struct mdss_edp_drv_pdata *)data;
 
 	while (1) {
-		wait_event(ep->event_q, (ep->event_pndx != ep->event_gndx));
+		if (wait_event_interruptible(ep->event_q,
+			(ep->event_pndx != ep->event_gndx)) != 0)
+			continue;
+
 		spin_lock_irqsave(&ep->event_lock, flag);
 		if (ep->event_pndx == ep->event_gndx) {
 			spin_unlock_irqrestore(&ep->event_lock, flag);

--- a/drivers/video/msm/mdss/mdss_fb.c
+++ b/drivers/video/msm/mdss/mdss_fb.c
@@ -1944,9 +1944,10 @@ static int __mdss_fb_display_thread(void *data)
 				mfd->index);
 
 	while (1) {
-		wait_event(mfd->commit_wait_q,
+		if (wait_event_interruptible(mfd->commit_wait_q,
 				(atomic_read(&mfd->commits_pending) ||
-				 kthread_should_stop()));
+				 kthread_should_stop())) != 0)
+			continue;
 
 		if (kthread_should_stop())
 			break;


### PR DESCRIPTION
Based on @cyanogen's commit this replaces uninterruptible waits in
worker threads with their interruptible versions to bring the load
back down to zero at idle.

To make sure that the waits can never be skipped by interrupts, the
return values are checked and jumped back when the event has not yet
finished.

Change-Id: I14bad4af135b1594e235e2252cb484cb34d91054
