### PR TITLE
g3: revert low power mode for HPH bias currents

### DIFF
--- a/sound/soc/codecs/wcd9320.c
+++ b/sound/soc/codecs/wcd9320.c
@@ -6486,7 +6486,11 @@ static const struct wcd9xxx_reg_mask_val taiko_reg_defaults[] = {
 	TAIKO_REG_VAL(TAIKO_A_CDC_CONN_MAD, 0x01),
 
 	/* Set HPH Path to low power mode */
+#ifdef CONFIG_MACH_LGE
+	TAIKO_REG_VAL(TAIKO_A_RX_HPH_BIAS_PA, 0x7a),
+#else
 	TAIKO_REG_VAL(TAIKO_A_RX_HPH_BIAS_PA, 0x55),
+#endif
 
 	/* BUCK default */
 	TAIKO_REG_VAL(WCD9XXX_A_BUCK_CTRL_CCL_4, 0x51),


### PR DESCRIPTION
- reduces the audio hissing noticeably
- caf enabled it, LG disabled it again

Change-Id: I5ed0218c853048c1e28ed1ea73297154891990dc
